### PR TITLE
Set skipLibCheck: true in tsconfig.json to ignore errors when buildin…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "lib": [
       "es2017",
       "dom"
-    ]
+    ],
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Setting "skipLibCheck": true in tsconfig.json makes sure that errors that will prevent the project from successfully building are eliminated.